### PR TITLE
Prevent message looping by getting id/username at runtime instead

### DIFF
--- a/DiscordHelper.js
+++ b/DiscordHelper.js
@@ -116,7 +116,7 @@ var DiscordHelper =
 	},
 	discordMessageReceived : function(user, userID, channelID, message, rawEvent)
 	{
-		if(user != config.discord_username)
+		if(userID != DiscordHelper.discord.id)
 		{
 			var pipe = pipes.getPipe({ discordId: channelID });
 			if(pipe != null)

--- a/SkypeHelper.js
+++ b/SkypeHelper.js
@@ -160,7 +160,7 @@ var SkypeHelper =
 	{
 		messages.forEach(function (message) 
 		{
-			var spypeIsNotSender = (message.resource.from.toLowerCase().indexOf(config.skype_username.toLowerCase()) === -1);
+			var spypeIsNotSender = (message.resource.from.indexOf(SkypeHelper.skyweb.skypeAccount.selfInfo.username) === -1);
 			if(spypeIsNotSender && message.resource.messagetype !== 'Control/Typing' && message.resource.messagetype !== 'Control/ClearTyping')
 			{
 				var conversationLink = message.resource.conversationLink;

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,6 @@
 {
  "skype_username" : "bot",
  "skype_password" : "PASSWORD",
- "discord_username" : "bot",
  "discord_email" : "bot@test.com",
  "discord_password" : "PASSWORD",
  "discord_token" : "TOKEN",


### PR DESCRIPTION
Spype has a problem currently where the Skype username is used both to login and to block messages sent by the bot in skypeMessagesReceived. This doesn't work for (newer) users who cannot sign into Skype with a username, who must instead use an email, and it results in message looping.
Spype also currently requires you to set the Discord bot username in its config for the same purpose in discordMessageReceived, which is inconvenient.

I found that this can be avoided quite easily, by instead fetching the Skype username we are using from Skyweb, and similarly the userID of the bot from Discord IO.
This seems to work well for me, with an email based Skype user account and a token based Discord bot.

I've also included a second commit which removes the discord_username from the config.json file, since it has no use with this fix.

Best regards!